### PR TITLE
Allow user-configured templateOptions

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -18,9 +18,13 @@ TemplateRenderer.prototype.beforeGenerate = function () {
  */
 exports.publish = function(taffyData, opts, tutorials) {
 
-  var templateOptions = {
-    includeNav: false
-  };
+  var templateOptions = opts.templateOptions;
+
+  if (!templateOptions) {
+    templateOptions = {
+      includeNav: false
+    }
+  }
 
   var templateRenderer = new TemplateRenderer(taffyData, tutorials, opts, templateOptions);
 


### PR DESCRIPTION
Currently, the templateOptions is hardcoded to just set `includeNav: false`. This PR allows a user to set a `templateOptions` option to allow overriding these options to include things such as `outputSourceFiles: false` if a user wants to exclude the source files.